### PR TITLE
docs: render takes an object of props

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ built-in lifecycle events are:
 ### `component.emit(eventname, [props])`
 Trigger a handler on the component.
 
-### `DOMNode = component.render([props])`
+### `DOMNode = component.render(props)`
 Render an element.
 
 ## See Also


### PR DESCRIPTION
With the former syntax I was doing `component.render(fields, rows)` but in fact I needed to do `.render({fields, rows})`. Not sure which is intended, but this PR at least updates the docs to reflect that.