### PR TITLE
use shallow-equal fork to make it work with Element comparisons

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nanologger": "^1.0.2",
     "nanomorph": "^4.0.3",
     "nanotiming": "^1.0.0",
-    "shallow-equal": "^1.0.0"
+    "shallow-equal": "github:juliangruber/shallow-equal#add/element-checks"
   },
   "devDependencies": {
     "dependency-check": "^2.8.0",


### PR DESCRIPTION
to work around https://github.com/moroshko/shallow-equal/pull/2 until it is merged (or we decided to publish our own version), this makes comparisons work for elements where

```
elA !== elB && elA.isSameNode(elB)
```